### PR TITLE
feat(api): add signup.handler option and check signup.enabled

### DIFF
--- a/api/src/OAuthHandler.ts
+++ b/api/src/OAuthHandler.ts
@@ -40,8 +40,7 @@ export interface OAuthHandlerOptions<TUser = Record<string | number, any>> {
       userExistsWithEmail?: string
       userExistsFromProvider?: string
       alreadyLoggedIn?: string
-      createUserError?: string
-      flowNotEnabled?: string
+      createUserError?: string 
     } 
     /**
     * Whatever you want to happen to your data after a new user has been created.


### PR DESCRIPTION
- Splits the signup and login validation and checks the dbAuthHandler signup.enabled now.
- Adds a signup.handler for any actions after a user gets created.

can be used like this:
```
  const oAuthHandler = new OAuthHandler(event, context, authHandler, {
    // The name of the property you'd call on `db` to access your OAuth table.
    // i.e. if your Prisma model is named `OAuth` this value would be `oAuth`, as in `db.oAuth`
    oAuthModelAccessor: 'oAuth',
    // You can instead do `enabledProviders: {}`, but I find it more clear to be explicitly not enabling these
    // We'll enable at least one of these later on, but leave it like this for now
    enabledProviders: { apple: false, github: false, google: true },

    signup: {
      // The signup handler is called after a user has been successfully created
      handler: async (user) => {
        await sendConfirmationEmail(user.id)
        return user
      },
    },
  })
  ```